### PR TITLE
added storage for market op logs

### DIFF
--- a/build/infrastructure/main/st-marketoplogs.tf
+++ b/build/infrastructure/main/st-marketoplogs.tf
@@ -1,0 +1,56 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+locals {
+  marketoplogs_container_name = "marketoplogs"
+}
+
+module "st_market_operator_logs" {
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/storage-account?ref=5.1.0"
+
+  name                      = "marketoplogs"
+  project_name              = var.domain_name_short
+  environment_short         = var.environment_short
+  environment_instance      = var.environment_instance
+  resource_group_name       = azurerm_resource_group.this.name
+  location                  = azurerm_resource_group.this.location
+  account_replication_type  = "LRS"
+  access_tier               = "Hot"
+  account_tier              = "Standard"
+  containers                = [
+    {
+      name = local.marketoplogs_container_name,
+    },
+  ]
+
+  tags                      = azurerm_resource_group.this.tags
+}
+
+module "kvs_st_market_operator_logs_primary_connection_string" {
+  source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-secret?ref=5.1.0"
+  name          = "st-marketoplogs-primary-connection-string"
+  value         = module.st_market_operator_logs.primary_connection_string
+  key_vault_id  = module.kv_shared.id
+
+  tags          = azurerm_resource_group.this.tags
+}
+
+module "kvs_st_market_operator_logs_container_name" {
+  source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-secret?ref=5.1.0"
+
+  name          = "st-marketoplogs-container-name"
+  value         = local.marketoplogs_container_name
+  key_vault_id  = module.kv_shared.id
+
+  tags          = azurerm_resource_group.this.tags
+}

--- a/build/infrastructure/main/st-marketoplogs.tf
+++ b/build/infrastructure/main/st-marketoplogs.tf
@@ -38,6 +38,7 @@ module "st_market_operator_logs" {
 
 module "kvs_st_market_operator_logs_primary_connection_string" {
   source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-secret?ref=5.1.0"
+  
   name          = "st-marketoplogs-primary-connection-string"
   value         = module.st_market_operator_logs.primary_connection_string
   key_vault_id  = module.kv_shared.id


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-shared-resources) before we can accept your contribution. --->

## Description

adding new storage account with one container for request and response logs. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
