### PR TITLE
Share correct actor register database name

### DIFF
--- a/build/infrastructure/main/sql-ActorRegister.tf
+++ b/build/infrastructure/main/sql-ActorRegister.tf
@@ -33,7 +33,7 @@ module "kvs_sql_actor_register_database_name" {
   source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-secret?ref=5.1.0"
 
   name          = "sql-actor-register-database-name"
-  value         = local.actor_register_database_name
+  value         = module.sqldb_actor_register.name
   key_vault_id  = module.kv_shared.id
 
   tags          = azurerm_resource_group.this.tags


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-shared-resources) before we can accept your contribution. --->

## Description

Currently, only the basename (without environment, etc) is stored in the shared key vault. E.g. `actorregister` instead of `sqldb-actorregister-sharedres-u-001`. This PR fixes this so it becomes the correct and full database name.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
