### PR TITLE
Added workflow cleaner

### DIFF
--- a/.github/actions/cleanup-workflows/action.yml
+++ b/.github/actions/cleanup-workflows/action.yml
@@ -1,0 +1,73 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Cleanup workflows
+description: 'Removes runs from all workflows except ci.yml, cd.yml and the other workflows specified in the exluded list'
+inputs:
+  PAT_TOKEN:
+    description: 'Personal access token used for authenticating against the github REST Api'
+    required: true
+  REPOSITORY:
+    description: 'Repository the cleanup job is run towards. {owner}/{repository}'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup job
+      shell: bash
+      run: |
+        mkdir ${{ github.workspace }}/remote
+
+    - uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.REPOSITORY }}
+        ref: 'main'
+        token: ${{ inputs.PAT_TOKEN }}
+        path: ${{ github.workspace }}/remote
+
+    # We only operate on files not in main. So we load all filenames into a comma separated string, to pass to the job
+    # The nullglob option causes the array to be empty if there are no matches.
+    - name: Get excluded workflows
+      id: get-excluded-workflows
+      shell: bash
+      run: |
+        shopt -s nullglob
+
+        # doing cd into directory, to only get filenames and complete filepath
+        cd ${{ github.workspace }}/remote/.github/workflows
+        workflow_files_array=(*.yml)
+
+        # Reading files into comma separated string
+        workflow_files=""
+        for file in "${workflow_files_array[@]}"; do
+          if [ -z "$workflow_files" ]
+          then
+            workflow_files="${file}"
+          else
+            workflow_files="${workflow_files},${file}"
+          fi
+        done
+
+        echo "::set-output name=EXCLUDED_WORKFLOWS::$workflow_files"
+
+    - name: Install npm packages
+      shell: bash
+      run: |
+        npm install @actions/core
+        npm install @actions/github
+
+    - name: Cleanup
+      shell: bash
+      run: |
+        node ${{ github.action_path }}/index.js ${{ inputs.PAT_TOKEN }} ${{ inputs.REPOSITORY }} ${{ steps.get-excluded-workflows.outputs.EXCLUDED_WORKFLOWS }}

--- a/.github/actions/cleanup-workflows/index.js
+++ b/.github/actions/cleanup-workflows/index.js
@@ -1,0 +1,98 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+// Args
+const [, , pat_token, repository, excluded_workflows] = process.argv;
+
+// Since github throttles requests on 5.000, we dont want to spend all.
+// To make sure a single execution does not trigger that, we will throttle at 4.000
+// https://docs.github.com/en/developers/apps/building-github-apps/rate-limits-for-github-apps#user-to-server-requests
+// Can possibly be capped at 15.000 by looking into Github Apps
+let githubApiCallsThrottleCap = 4000;
+let githubApiCallsUsed = 0;
+
+// Define the main function
+const main = async () => {
+  try {
+    console.log('Initiating cleanup of workflows');
+
+    if (!repository || !pat_token) {
+      console.log('repository', repository);
+      console.log('pat_token', pat_token);
+      throw new Error('Missing arguments');
+    }
+
+    if (excluded_workflows) {
+      console.log('Skipping excluded workflows: ', excluded_workflows);
+    }
+
+    // Since github variable github.repository is in the format {owner}/{repository}
+    // we split it to get each value. 
+    const splittedRepositoryString = repository.split('/');
+    const owner = splittedRepositoryString[0];
+    const repo = splittedRepositoryString[1];
+
+    // Initiate octokit
+    const octokit = new github.getOctokit(pat_token);
+
+    // Pulling used github calls from rate_limit endpoint
+    const rateLimitResponse = await octokit.request('GET /rate_limit');
+    githubApiCallsUsed = rateLimitResponse.data.rate.used;
+    if (githubApiCallsUsed >= githubApiCallsThrottleCap){
+      throw new Error('Close to spending up throttles for the current hour, please try again later.');
+    }
+    
+    const workflowsResponse = await octokit.rest.actions.listRepoWorkflows({
+      owner,
+      repo,
+    });
+    githubApiCallsUsed++;
+
+    if (workflowsResponse.data.workflows){
+      // Iterating through workflows
+      workflowsResponse.data.workflows.map(async (workflow) => {
+        const pathWithoutPrefix = workflow.path.replace('.github/workflows/', '');
+
+        // Only handling non excluded workflows
+        if (excluded_workflows && !excluded_workflows.includes(pathWithoutPrefix)) {
+          const workflowRuns = await octokit.rest.actions.listWorkflowRuns({
+            owner,
+            repo,
+            workflow_id: workflow.id,
+          });
+          githubApiCallsUsed++;
+          if (githubApiCallsUsed >= githubApiCallsThrottleCap){
+            throw new Error('Close to spending up throttles for the current hour, please try again later.');
+          }
+
+          if (workflowRuns.data.workflow_runs) {
+            console.log(`Cleaning runs of workflow ${workflow.name}`);
+
+            // Iterating workflow runs
+            workflowRuns.data.workflow_runs.map(async (workflowRun) => {
+              await octokit.rest.actions.deleteWorkflowRun({
+                owner,
+                repo,
+                run_id: workflowRun.id,
+              });
+              githubApiCallsUsed++;
+              if (githubApiCallsUsed >= githubApiCallsThrottleCap){
+                throw new Error('Close to spending up throttles for the current hour, please try again later.');
+              }
+
+              console.log(`Run ${workflowRun.id} deleted`);
+            });
+          }
+        }
+      });
+    }
+  } catch (error) {
+    console.log(error.message);
+    core.setFailed(error.message);
+  }
+
+  console.log('Workflow cleanup done');
+}
+
+// Call the main function to run the action
+main();

--- a/.github/workflows/cleanup-workflows.yml
+++ b/.github/workflows/cleanup-workflows.yml
@@ -1,0 +1,36 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Cleanup workflows
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        type: string
+        description: 'Repository the cleanup job is run towards. {owner}/{repository}'
+        required: true
+
+jobs:
+  cleanup_workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 'workflow-cleaner'
+
+      - name: Cleanup workflow
+        uses: ./.github/actions/cleanup-workflows
+        with:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          REPOSITORY: ${{ inputs.repository }}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-shared-resources) before we can accept your contribution. --->

## Description
This cleaner can be used to cleanup workflows of all repositories.

It has build in throttling to make sure we dont get throttled by Github, which will block all other workflows from running.

The reason for placing this in shared resources is that .github does not contain any actual running workflows, only reusable from other domains, and geh-core is more of a nuget package repo as we speak.
That might be subject to change in the future, in which we could move this