### PR TITLE
Install .NET 5 (so we have 5 and 6 side-by-side)

### DIFF
--- a/build/landingzone/main/scripts/setup-deploy-agent.sh
+++ b/build/landingzone/main/scripts/setup-deploy-agent.sh
@@ -76,6 +76,12 @@ rm packages-microsoft-prod.deb
 # See https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#how-to-install-other-versions
 #
 
+# .NET SDK 5.0
+sudo apt-get update; \
+  sudo apt-get install -y apt-transport-https && \
+  sudo apt-get update && \
+  sudo apt-get install -y dotnet-sdk-5.0
+
 # .NET SDK 6.0
 sudo apt-get update; \
   sudo apt-get install -y apt-transport-https && \


### PR DESCRIPTION
## Description

To be able to rollout the use of the deployment agent even before all domains have upgraded to .NET 6, we want to install .NET 5 as well.