### PR TITLE
Remove custom inbound header+change outbound

### DIFF
--- a/build/infrastructure/main/apima-b2b.tf
+++ b/build/infrastructure/main/apima-b2b.tf
@@ -63,9 +63,6 @@ module "apima_b2b" {
                     </choose>
                 </when>
             </choose>
-            <set-header name="Correlation-ID" exists-action="override">
-                <value>@($"{context.RequestId}")</value>
-            </set-header>
             <set-header name="RequestTime" exists-action="override">
                 <value>@(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))</value>
             </set-header>
@@ -76,7 +73,7 @@ module "apima_b2b" {
           <outbound>
               <base />
               <set-header name="CorrelationId" exists-action="override">
-                  <value>@($"{context.RequestId}")</value>
+                  <value>@($"{context.Operation.Id}")</value>
               </set-header>
           </outbound>
           <on-error>


### PR DESCRIPTION
* Content of inbound custom header is already per default searchable in app insights, and the DH3 middleware doesn't use it
* Outbound value should comply with: https://docs.microsoft.com/en-us/azure/azure-monitor/app/correlation#correlation-headers-using-w3c-tracecontext